### PR TITLE
Added CompositeCodec to support reading/writing composite columns

### DIFF
--- a/cassie-core/src/main/scala/com/twitter/cassie/codecs/CompositeCodec.scala
+++ b/cassie-core/src/main/scala/com/twitter/cassie/codecs/CompositeCodec.scala
@@ -4,7 +4,7 @@ import com.twitter.cassie.types.Composite
 import java.nio.ByteBuffer
 
 object CompositeCodec {
-  def apply[A](codec: Codec[A]) : CompositeCodec[A] = new CompositeCodec(codec)
+  def apply[A](codec: Codec[A]): CompositeCodec[A] = new CompositeCodec(codec)
 }
 
 class CompositeCodec[A](codec: Codec[A]) extends Codec[Composite[A]] {

--- a/cassie-core/src/main/scala/com/twitter/cassie/codecs/CompositeCodec.scala
+++ b/cassie-core/src/main/scala/com/twitter/cassie/codecs/CompositeCodec.scala
@@ -1,0 +1,11 @@
+package com.twitter.cassie.codecs
+
+import com.twitter.cassie.types.Composite
+import java.nio.ByteBuffer
+
+object CompositeCodec extends Codec[Composite] {
+
+  def encode(composite: Composite) = composite.encode
+  def decode(buf: ByteBuffer) = Composite.decode(buf)
+
+}

--- a/cassie-core/src/main/scala/com/twitter/cassie/codecs/CompositeCodec.scala
+++ b/cassie-core/src/main/scala/com/twitter/cassie/codecs/CompositeCodec.scala
@@ -3,11 +3,7 @@ package com.twitter.cassie.codecs
 import com.twitter.cassie.types.Composite
 import java.nio.ByteBuffer
 
-object CompositeCodec {
-  def apply[A](codec: Codec[A]): CompositeCodec[A] = new CompositeCodec(codec)
-}
-
-class CompositeCodec[A](codec: Codec[A]) extends Codec[Composite[A]] {
-  def encode(composite: Composite[A]) = composite.encode
-  def decode(buf: ByteBuffer) = Composite.decode(buf, codec)
+object CompositeCodec extends Codec[Composite] {
+  def encode(composite: Composite) = composite.encode
+  def decode(buf: ByteBuffer) = Composite.decode(buf)
 }

--- a/cassie-core/src/main/scala/com/twitter/cassie/codecs/CompositeCodec.scala
+++ b/cassie-core/src/main/scala/com/twitter/cassie/codecs/CompositeCodec.scala
@@ -3,9 +3,11 @@ package com.twitter.cassie.codecs
 import com.twitter.cassie.types.Composite
 import java.nio.ByteBuffer
 
-object CompositeCodec extends Codec[Composite] {
+object CompositeCodec {
+  def apply[A](codec: Codec[A]) : CompositeCodec[A] = new CompositeCodec(codec)
+}
 
-  def encode(composite: Composite) = composite.encode
-  def decode(buf: ByteBuffer) = Composite.decode(buf)
-
+class CompositeCodec[A](codec: Codec[A]) extends Codec[Composite[A]] {
+  def encode(composite: Composite[A]) = composite.encode
+  def decode(buf: ByteBuffer) = Composite.decode(buf, codec)
 }

--- a/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
+++ b/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
@@ -1,0 +1,81 @@
+package com.twitter.cassie.types
+
+import java.nio.ByteBuffer
+import scala.collection.mutable
+
+class Composite {
+
+  private var _components = new mutable.ListBuffer[Component]
+
+  def apply(idx: Int) = _components(idx)
+
+  def get(idx: Int) = apply(idx)
+
+  def length = _components.length
+
+  def components = _components.toSeq
+
+  def addComponent(component: Component) : Composite = {
+    _components += component
+    this
+  }
+
+  def encode : ByteBuffer = {
+    val totalLength = _components.foldLeft(0)(_ + 2 + _.value.remaining + 1)  //each component has 2-byte length + value + terminator
+    val encoded = ByteBuffer.allocate(totalLength)
+
+    _components.foreach { component =>
+      val length = component.value.remaining
+      // add length
+      encoded.putShort(length.toShort)
+      // add value
+      encoded.put(component.value)
+      // add terminator
+      encoded.put(component.equality)
+    }
+
+    encoded.rewind
+    encoded
+  }
+}
+
+object Composite {
+
+  def apply(components: Component*) : Composite = {
+    val composite = new Composite
+    components.foreach(composite.addComponent(_))
+    composite
+  }
+
+  def decode(encoded: ByteBuffer) : Composite = apply(getComponents(encoded).reverse:_*)
+
+  private def getComponents(encoded: ByteBuffer, acc: Seq[Component] = Seq()) : Seq[Component] =
+    if (encoded.remaining == 0) acc
+    else getComponents(encoded, componentFromByteBuffer(encoded) +: acc)
+
+  private def componentFromByteBuffer(buf: ByteBuffer) = {
+    val length = buf.getShort
+    val value = new Array[Byte](length)
+    buf.get(value)
+    val equality = ComponentEquality.fromByte(buf.get)
+    Component(ByteBuffer.wrap(value), equality)
+  }
+
+}
+
+object ComponentEquality {
+
+  type ComponentEquality = Byte
+  val EQ:Byte = 0x0
+  val LTE:Byte = -0x1
+  val GTE:Byte = 0x1
+
+  def fromByte(b: Byte) : ComponentEquality = {
+    if (b > 0) GTE
+    else if (b < 0) LTE
+    else EQ
+  }
+
+}
+
+case class Component(value: ByteBuffer, equality: ComponentEquality.ComponentEquality = ComponentEquality.EQ)

--- a/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
+++ b/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
@@ -92,23 +92,23 @@ case class DecodedComposite5[A, B, C, D, E](_1: Component[A], _2: Component[B], 
 
 object Decoder {
 
-  def convert[T](c: Component[ByteBuffer], codec: Codec[T]) : Component[T] = Component(codec.decode(c.value), codec, c.equality)
+  def convert[T](c: Component[ByteBuffer], codec: Codec[T]): Component[T] = Component(codec.decode(c.value), codec, c.equality)
 
   def apply[A, B](codecA: Codec[A], codecB: Codec[B]) = new {
-    def decode(composite: Composite) : DecodedComposite2[A, B] =
+    def decode(composite: Composite): DecodedComposite2[A, B] =
       DecodedComposite2(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
                         convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB))
   }
 
   def apply[A, B, C](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C]) = new {
-    def decode(composite: Composite) : DecodedComposite3[A, B, C] =
+    def decode(composite: Composite): DecodedComposite3[A, B, C] =
       DecodedComposite3(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
                         convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
                         convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC))
   }
 
   def apply[A, B, C, D](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C], codecD: Codec[D]) = new {
-    def decode(composite: Composite) : DecodedComposite4[A, B, C, D] =
+    def decode(composite: Composite): DecodedComposite4[A, B, C, D] =
       DecodedComposite4(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
                         convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
                         convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC),
@@ -116,7 +116,7 @@ object Decoder {
   }
 
   def apply[A, B, C, D, E](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C], codecD: Codec[D], codecE: Codec[E]) = new {
-    def decode(composite: Composite) : DecodedComposite5[A, B, C, D, E] =
+    def decode(composite: Composite): DecodedComposite5[A, B, C, D, E] =
       DecodedComposite5(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
                         convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
                         convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC),

--- a/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
+++ b/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
@@ -94,57 +94,33 @@ object Decoder {
 
   def convert[T](c: Component[ByteBuffer], codec: Codec[T]) : Component[T] = Component(codec.decode(c.value), codec, c.equality)
 
-  def apply[A, B](codecA: Codec[A], codecB: Codec[B]) = Decoder2(codecA, codecB)
-  def apply[A, B, C](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C]) = Decoder3(codecA, codecB, codecC)
-  def apply[A, B, C, D](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C], codecD: Codec[D]) =
-    Decoder4(codecA, codecB, codecC, codecD)
-  def apply[A, B, C, D, E](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C], codecD: Codec[D], codecE: Codec[E]) =
-    Decoder5(codecA, codecB, codecC, codecD, codecE)
+  def apply[A, B](codecA: Codec[A], codecB: Codec[B]) = new {
+    def decode(composite: Composite) : DecodedComposite2[A, B] =
+      DecodedComposite2(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
+                        convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB))
+  }
 
-}
+  def apply[A, B, C](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C]) = new {
+    def decode(composite: Composite) : DecodedComposite3[A, B, C] =
+      DecodedComposite3(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
+                        convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
+                        convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC))
+  }
 
-import Decoder._
+  def apply[A, B, C, D](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C], codecD: Codec[D]) = new {
+    def decode(composite: Composite) : DecodedComposite4[A, B, C, D] =
+      DecodedComposite4(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
+                        convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
+                        convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC),
+                        convert(composite(3).asInstanceOf[Component[ByteBuffer]], codecD))
+  }
 
-case class Decoder2[A, B](codecA: Codec[A],
-                          codecB: Codec[B]) {
-
-  def decode(composite: Composite): DecodedComposite2[A, B] =
-    DecodedComposite2(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
-                      convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB))
-}
-
-case class Decoder3[A, B, C](codecA: Codec[A],
-                             codecB: Codec[B],
-                             codecC: Codec[C]) {
-
-  def decode(composite: Composite): DecodedComposite3[A, B, C] =
-    DecodedComposite3(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
-                      convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
-                      convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC))
-}
-
-case class Decoder4[A, B, C, D](codecA: Codec[A],
-                                codecB: Codec[B],
-                                codecC: Codec[C],
-                                codecD: Codec[D]) {
-
-  def decode(composite: Composite): DecodedComposite4[A, B, C, D] =
-    DecodedComposite4(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
-                      convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
-                      convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC),
-                      convert(composite(3).asInstanceOf[Component[ByteBuffer]], codecD))
-}
-
-case class Decoder5[A, B, C, D, E](codecA: Codec[A],
-                                   codecB: Codec[B],
-                                   codecC: Codec[C],
-                                   codecD: Codec[D],
-                                   codecE: Codec[E]) {
-
-  def decode(composite: Composite): DecodedComposite5[A, B, C, D, E] =
-    DecodedComposite5(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
-                      convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
-                      convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC),
-                      convert(composite(3).asInstanceOf[Component[ByteBuffer]], codecD),
-                      convert(composite(4).asInstanceOf[Component[ByteBuffer]], codecE))
+  def apply[A, B, C, D, E](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C], codecD: Codec[D], codecE: Codec[E]) = new {
+    def decode(composite: Composite) : DecodedComposite5[A, B, C, D, E] =
+      DecodedComposite5(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
+                        convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
+                        convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC),
+                        convert(composite(3).asInstanceOf[Component[ByteBuffer]], codecD),
+                        convert(composite(4).asInstanceOf[Component[ByteBuffer]], codecE))
+  }
 }

--- a/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
+++ b/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
@@ -2,11 +2,11 @@ package com.twitter.cassie.types
 
 import java.nio.ByteBuffer
 import scala.collection.mutable
-import com.twitter.cassie.codecs.Codec
+import com.twitter.cassie.codecs.{ByteArrayCodec, Codec}
 
-class Composite[A](codec: Codec[A]) {
+class Composite {
 
-  private[this] val _components = new mutable.ListBuffer[Component[A]]
+  private[this] var _components = new mutable.ListBuffer[Component[_]]
 
   def apply(idx: Int) = _components(idx)
 
@@ -16,25 +16,25 @@ class Composite[A](codec: Codec[A]) {
 
   def components = _components.toSeq
 
-  def addComponent(component: Component[A]): Composite[A] = {
+  def addComponent(component: Component[_]): Composite = {
     _components += component
     this
   }
 
   def encode: ByteBuffer = {
+    val encodedComponents = _components.map(c => (c.encoded, c.equality)).toSeq
     //each component has 2-byte length + value + terminator
-    val totalLength = _components.foldLeft(0) { (acc, c) => acc + 2 + codec.encode(c.value).remaining + 1 }
+    val totalLength = encodedComponents.foldLeft(0) { (acc, c) => acc + 2 + c._1.remaining + 1 }
     val encoded = ByteBuffer.allocate(totalLength)
 
-    _components.foreach { component =>
-      val encComp = codec.encode(component.value)
-      val length = encComp.remaining
+    encodedComponents.foreach { case (component, equality) =>
+      val length = component.remaining
       // add length
       encoded.putShort(length.toShort)
       // add value
-      encoded.put(encComp)
+      encoded.put(component)
       // add terminator
-      encoded.put(component.equality)
+      encoded.put(equality)
     }
 
     encoded.rewind
@@ -44,24 +44,24 @@ class Composite[A](codec: Codec[A]) {
 
 object Composite {
 
-  def apply[A](codec: Codec[A], components: Component[A]*): Composite[A] = {
-    val composite = new Composite(codec)
+  def apply(components: Component[_]*): Composite = {
+    val composite = new Composite
     components.foreach(composite.addComponent(_))
     composite
   }
 
-  def decode[A](encoded: ByteBuffer, codec: Codec[A]): Composite[A] = apply(codec, getComponents(encoded, codec).reverse:_*)
+  def decode(encoded: ByteBuffer): Composite = apply(getComponents(encoded).reverse:_*)
 
-  private def getComponents[A](encoded: ByteBuffer, codec: Codec[A], acc: Seq[Component[A]] = Seq()): Seq[Component[A]] =
+  private def getComponents(encoded: ByteBuffer, acc: Seq[Component[ByteBuffer]] = Seq()): Seq[Component[ByteBuffer]] =
     if (encoded.remaining == 0) acc
-    else getComponents(encoded, codec, componentFromByteBuffer(encoded, codec) +: acc)
+    else getComponents(encoded, componentFromByteBuffer(encoded) +: acc)
 
-  private def componentFromByteBuffer[A](buf: ByteBuffer, codec: Codec[A]) = {
+  private def componentFromByteBuffer(buf: ByteBuffer) = {
     val length = buf.getShort
     val value = new Array[Byte](length)
     buf.get(value)
     val equality = ComponentEquality.fromByte(buf.get)
-    Component(codec.decode(ByteBuffer.wrap(value)), equality)
+    Component(ByteBuffer.wrap(value), ByteArrayCodec, equality)
   }
 
 }
@@ -81,4 +81,70 @@ object ComponentEquality {
 
 }
 
-case class Component[A](value: A, equality: ComponentEquality.ComponentEquality = ComponentEquality.EQ)
+case class Component[A](value: A, codec: Codec[A], equality: ComponentEquality.ComponentEquality = ComponentEquality.EQ) {
+  val encoded: ByteBuffer = codec.encode(value)
+}
+
+case class DecodedComposite2[A, B](_1: Component[A], _2: Component[B])
+case class DecodedComposite3[A, B, C](_1: Component[A], _2: Component[B], _3: Component[C])
+case class DecodedComposite4[A, B, C, D](_1: Component[A], _2: Component[B], _3: Component[C], _4: Component[D])
+case class DecodedComposite5[A, B, C, D, E](_1: Component[A], _2: Component[B], _3: Component[C], _4: Component[D], _5: Component[E])
+
+object Decoder {
+
+  def convert[T](c: Component[ByteBuffer], codec: Codec[T]) : Component[T] = Component(codec.decode(c.value), codec, c.equality)
+
+  def apply[A, B](codecA: Codec[A], codecB: Codec[B]) = Decoder2(codecA, codecB)
+  def apply[A, B, C](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C]) = Decoder3(codecA, codecB, codecC)
+  def apply[A, B, C, D](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C], codecD: Codec[D]) =
+    Decoder4(codecA, codecB, codecC, codecD)
+  def apply[A, B, C, D, E](codecA: Codec[A], codecB: Codec[B], codecC: Codec[C], codecD: Codec[D], codecE: Codec[E]) =
+    Decoder5(codecA, codecB, codecC, codecD, codecE)
+
+}
+
+import Decoder._
+
+case class Decoder2[A, B](codecA: Codec[A],
+                          codecB: Codec[B]) {
+
+  def decode(composite: Composite): DecodedComposite2[A, B] =
+    DecodedComposite2(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
+                      convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB))
+}
+
+case class Decoder3[A, B, C](codecA: Codec[A],
+                             codecB: Codec[B],
+                             codecC: Codec[C]) {
+
+  def decode(composite: Composite): DecodedComposite3[A, B, C] =
+    DecodedComposite3(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
+                      convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
+                      convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC))
+}
+
+case class Decoder4[A, B, C, D](codecA: Codec[A],
+                                codecB: Codec[B],
+                                codecC: Codec[C],
+                                codecD: Codec[D]) {
+
+  def decode(composite: Composite): DecodedComposite4[A, B, C, D] =
+    DecodedComposite4(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
+                      convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
+                      convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC),
+                      convert(composite(3).asInstanceOf[Component[ByteBuffer]], codecD))
+}
+
+case class Decoder5[A, B, C, D, E](codecA: Codec[A],
+                                   codecB: Codec[B],
+                                   codecC: Codec[C],
+                                   codecD: Codec[D],
+                                   codecE: Codec[E]) {
+
+  def decode(composite: Composite): DecodedComposite5[A, B, C, D, E] =
+    DecodedComposite5(convert(composite(0).asInstanceOf[Component[ByteBuffer]], codecA),
+                      convert(composite(1).asInstanceOf[Component[ByteBuffer]], codecB),
+                      convert(composite(2).asInstanceOf[Component[ByteBuffer]], codecC),
+                      convert(composite(3).asInstanceOf[Component[ByteBuffer]], codecD),
+                      convert(composite(4).asInstanceOf[Component[ByteBuffer]], codecE))
+}

--- a/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
+++ b/cassie-core/src/main/scala/com/twitter/cassie/types/Composite.scala
@@ -6,7 +6,7 @@ import com.twitter.cassie.codecs.{ByteArrayCodec, Codec}
 
 class Composite {
 
-  private[this] var _components = new mutable.ListBuffer[Component[_]]
+  private[this] val _components = new mutable.ListBuffer[Component[_]]
 
   def apply(idx: Int) = _components(idx)
 


### PR DESCRIPTION
This codec allows for operations on composite columns, which is currently not supported in Cassie.  Example usage:

``` scala
val cluster = new Cluster("localhost", 9160)
val keyspace = cluster.keyspace("test").connect()
val compositeTest = keyspace.columnFamily("CompositeTest", Utf8Codec, CompositeCodec, Utf8Codec)
                            .consistency(ReadConsistency.One)
                            .consistency(WriteConsistency.One)

val composite = Composite(Component("c1", Utf8Codec), Component(2, LongCodec))
compositeTest.insert("testkey", Column(composite, "testval2"))()

println("row ==")
compositeTest.getRow("testkey")().foreach(c => printCol(c._2))

println("one col ==")
compositeTest.getRowSlice("testkey2",
                          Some(Composite(Component("c1", Utf8Codec, ComponentEquality.EQ))),
                          Some(Composite(Component("c1", Utf8Codec, ComponentEquality.GTE))),
                          Int.MaxValue)()
             .foreach(printCol)

// Decoding a composite
val decoder = Decoder(Utf8Codec, LongCodec)

def printCol(c: Column[Composite, String]) = {
  val colName = decoder.decode(c.name)
  val c1 = colName._1.value
  val c2 = colName._2.value
  println(c1 + ":" + c2  + " = " + c.value)
}
```
