### PR TITLE
Documentation cleanup: Fresh links, improved formatting, build.sbt examp...

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ connection pools and do retries:
 
 (If you have some nodes with dramatically different latency—e.g., in another
 data center–or if you have a huge cluster, you can disable keyspace mapping
-via `mapHostsEvery(0.minutes)""" in which case clients will connect directly to
+via `mapHostsEvery(0.minutes)` in which case clients will connect directly to
 the seed hosts passed to "new Cluster".)
 "
 A Quick Note On Timestamps


### PR DESCRIPTION
Cleaned up some formatting issues, added a fresh link to SBT (now on Github vs Google Code), added an example to show how to use build.sbt to pull in resolver and dependencies.
